### PR TITLE
issue-66, fixed bug and updated unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Pending Version
 
+* Brian Fitzpatrick
+  * Fixed a bug where modifications to the expected state by deletion were not retained on children
+
 ## 0.3.4
 
 * Brian Fitzpatrick

--- a/lib/util/expected-state.js
+++ b/lib/util/expected-state.js
@@ -35,6 +35,7 @@ module.exports = ExpectedState = {
                     state: componentState,
                     options: componentOptions,
                     dynamicArea: component.dynamicArea,
+                    cloning: true,
                 });
             }
             clonedState._stashedStates = _.cloneDeep(this._stashedStates);
@@ -124,7 +125,7 @@ module.exports = ExpectedState = {
         });
         return newComponent;
     },
-    addComponent(component, state) {
+    addComponent(component, state, cloning) {
         if (!(typeof state === 'object') || Array.isArray(state)) {
             throw new SimulatoError.ACTION.EXPECTED_STATE_ERROR(
                 `component with name '${component.name}'`
@@ -141,7 +142,7 @@ module.exports = ExpectedState = {
             this._registerEvents(component);
         }
 
-        if (component.children) {
+        if (component.children && !cloning) {
             this._addChildren(component);
         }
 
@@ -195,7 +196,7 @@ module.exports = ExpectedState = {
     },
     createAndAddComponent(componentConfig) {
         let newComponent = this.createComponent(componentConfig);
-        this.addComponent(newComponent, componentConfig.state);
+        this.addComponent(newComponent, componentConfig.state, componentConfig.cloning);
     },
     delete(name) {
         let component = this.getComponent(name);

--- a/test/unit/lib/util/expected-state-tests.js
+++ b/test/unit/lib/util/expected-state-tests.js
@@ -223,6 +223,7 @@ describe('lib/util/expected-state.js', function() {
                                 state: 'myComponentState',
                                 options: 'myComponentOptions',
                                 dynamicArea: 'myDynamicArea',
+                                cloning: true,
                             }],
                         ]
                     );
@@ -1398,6 +1399,7 @@ describe('lib/util/expected-state.js', function() {
             expect(expectedState.addComponent.args).to.deep.equal([[
                 newComponent,
                 {someState: 'stateValue'},
+                undefined,
             ]]);
         });
     });

--- a/test/unit/lib/util/expected-state-tests.js
+++ b/test/unit/lib/util/expected-state-tests.js
@@ -871,7 +871,7 @@ describe('lib/util/expected-state.js', function() {
             });
         });
 
-        describe('if component.children is defined', function() {
+        describe('if component.children is defined and cloning is not true', function() {
             it('should call this._addChildren once with the passed in component', function() {
                 component.children = [
                     {
@@ -911,6 +911,56 @@ describe('lib/util/expected-state.js', function() {
                         },
                     ],
                 ]);
+            });
+            it('should add this children if children is not cloning', function() {
+                component.children = [
+                    {
+                        type: 'myComponent',
+                        name: 'myInstance',
+                        state: {
+                            property: 'value',
+                        },
+                        options: {
+                            option: 'option1',
+                        },
+                    },
+                ];
+
+                expectedState.addComponent.call(myThis, component, state, false);
+
+                expect(myThis._addChildren.args).to.deep.equal([
+                    [
+                        {
+                            children: [
+                                {
+                                    type: 'myComponent',
+                                    name: 'myInstance',
+                                    state: {
+                                        property: 'value',
+                                    },
+                                    options: {
+                                        option: 'option1',
+                                    },
+                                },
+                            ],
+                            name: 'instanceName',
+                            options: {},
+                            _currentWorkingModel: {
+                                key: 'value',
+                            },
+                        },
+                    ],
+                ]);
+            });
+        });
+        describe('if component.children is not defined and cloning is false', function() {
+            it('should not add the children', function() {
+                component.children = false;
+                expectedState._addChildren = sinon.stub();
+
+                expectedState.addComponent.call(myThis, component, state, false);
+
+                expect(expectedState._addChildren.callCount).to.equal(0);
             });
         });
 


### PR DESCRIPTION
Resolves issue: #66 

Changes proposed in this pull request:
- Deleting a child element removes does not re-add the child to the parent when cloning

@GannettDigital/simulato-core-contributors