### PR TITLE
issue-71: Updated element selectors to follow document selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Pending Version
 
+* Tom Dale
+  * Changed the selector methods inside elements to use
+    * getElementById
+    * querySelector
+    * querySelectorAll
+    * getElementsByTagName
+    * getElementsByClassName
+
 ## 0.3.5
 
 * Brian Fitzpatrick

--- a/lib/util/get-element-data.js
+++ b/lib/util/get-element-data.js
@@ -1,84 +1,104 @@
 'use strict';
 
 module.exports = function(elementsToGet, callback) {
-    let functions = {
-        findElement(key, value, elements) {
-            for (let currentElement of elements) {
-                if (currentElement[key] === value) {
-                    return currentElement;
-                } else if (!(currentElement.shadowRoot === null || currentElement.shadowRoot === undefined)) {
-                    let shadowElements = currentElement.shadowRoot.querySelectorAll('*');
-                    let match = functions.findElement(key, value, shadowElements);
-                    if (match) {
-                        return match;
-                    }
-                }
-            }
-        },
-        getElementData(elementsToFind) {
-            let data = {};
-            for (const element of elementsToFind) {
-                let type = element.selector.type;
-                let value = element.selector.value;
-                let key = element.selector.key;
-                let myElement;
+  let functions = {
+    getElementData(elementsToFind) {
+      let data = {};
+      for (const element of elementsToFind) {
+        let type = element.selector.type;
+        let value = element.selector.value;
+        let selectedDomValue;
+        switch (type) {
+          case 'querySelector':
+            selectedDomValue = document.querySelector(value);
+            break;
 
-                if (type === 'querySelector') {
-                    myElement = document.querySelector(value);
-                } else if (type === 'attribute') {
-                    let elements = document.getElementsByTagName('*');
-                    myElement = functions.findElement(key, value, elements);
-                } else {
-                    throw new Error(
-                        'Invalid selector.type for element ' + element.name + ' must be querySelector or attribute'
-                    );
-                }
-                if (myElement) {
-                    data[element.name] = functions.getElementInfo(myElement);
-                }
-            }
+          case 'querySelectorAll':
+            selectedDomValue = document.querySelectorAll(value);
+            break;
 
-            return data;
-        },
-        getElementInfo(element) {
-            return {
-                attributes: functions.extractNameAndValue(element.attributes),
-                name: element.name,
-                disabled: element.disabled,
-                innerHTML: element.innerHTML,
-                innerText: element.innerText,
-                hidden: element.hidden,
-                value: element.value,
-                webElement: element,
-                isDisplayed: functions.isDisplayed(element),
-            };
-        },
-        extractNameAndValue(attributes) {
-            const attributeObject = {};
-            for (const attribute of attributes) {
-                attributeObject[attribute.localName] = attribute.value;
-            }
-            return attributeObject;
-        },
-        isDisplayed(elem) {
-            if (!(elem instanceof Element)) throw Error('elem is not an element.');
-            const style = getComputedStyle(elem);
-            if (style.display === 'none') return false;
-            if (style.visibility !== 'visible') return false;
-            if (style.opacity < 0.1) return false;
-            if (elem.offsetWidth + elem.offsetHeight + elem.getBoundingClientRect().height +
-                elem.getBoundingClientRect().width === 0) {
-                return false;
-            }
-            return true;
-        },
-    };
+          case 'getElementById':
+            selectedDomValue = document.getElementById(value);
+            break;
 
-    try {
-        callback(functions.getElementData(elementsToGet));
-    } catch (error) {
-        callback(error);
-    }
+          case 'getElementsByTagName':
+            selectedDomValue = document.getElementsByTagName(value);
+            break;
 
-    return functions;
+          case 'getElementsByClassName':
+            selectedDomValue = document.getElementsByClassName(value);
+            break;
+
+          default:
+            throw new Error(
+              'Invalid selector.type for element \'' + element.name + '\' ' +
+              'must be querySelector, querySelectorAll, getElementById, getElementsByTagName, or getElementsByClassName'
+            );
+        }
+        if (selectedDomValue) {
+          data[element.name] = functions.getElementInfo(selectedDomValue);
+        }
+      }
+
+      return data;
+    },
+    getElementInfo(data) {
+      if (data.length) {
+        let elementInfo = [];
+        for (let i = 0; i < data.length; i++) {
+          elementInfo.push({
+            attributes: functions.extractNameAndValue(data[i].attributes),
+            name: data[i].name,
+            disabled: data[i].disabled,
+            innerHTML: data[i].innerHTML,
+            innerText: data[i].innerText,
+            hidden: data[i].hidden,
+            value: data[i].value,
+            webElement: data[i],
+            isDisplayed: functions.isDisplayed(data[i]),
+          });
+        }
+        return elementInfo;
+      } else {
+        return {
+          attributes: functions.extractNameAndValue(data.attributes),
+          name: data.name,
+          disabled: data.disabled,
+          innerHTML: data.innerHTML,
+          innerText: data.innerText,
+          hidden: data.hidden,
+          value: data.value,
+          webElement: data,
+          isDisplayed: functions.isDisplayed(data),
+        };
+      }
+    },
+    extractNameAndValue(attributes) {
+      const attributeObject = {};
+      for (const attribute of attributes) {
+        attributeObject[attribute.localName] = attribute.value;
+      }
+      return attributeObject;
+    },
+    isDisplayed(elem) {
+      if (!(elem instanceof Element)) throw Error('elem is not an element.');
+      const style = getComputedStyle(elem);
+      if (style.display === 'none') return false;
+      if (style.visibility !== 'visible') return false;
+      if (style.opacity < 0.1) return false;
+      if (elem.offsetWidth + elem.offsetHeight + elem.getBoundingClientRect().height +
+        elem.getBoundingClientRect().width === 0) {
+        return false;
+      }
+      return true;
+    },
+  };
+
+  try {
+    callback(functions.getElementData(elementsToGet));
+  } catch (error) {
+    callback(error);
+  }
+
+  return functions;
 };

--- a/lib/util/validators/validate-elements.js
+++ b/lib/util/validators/validate-elements.js
@@ -28,16 +28,17 @@ module.exports = function(elements, name, type) {
         `The selector 'type' field for '${value.name}' must be a string inside component '${type}'`
       );
     }
-    if (!(value.selector.type === 'attribute' || value.selector.type === 'querySelector')) {
+    let allowedType = (
+      value.selector.type === 'getElementById' ||
+      value.selector.type === 'querySelector' ||
+      value.selector.type === 'querySelectorAll' ||
+      value.selector.type === 'getElementsByTagName' ||
+      value.selector.type === 'getElementsByClassName'
+    );
+    if (!allowedType) {
       throw new SimulatoError.ELEMENT.ELEMENT_OBJECT_PROPERTY_TYPE(
-        `The selector 'type' field for '${value.name}' must be either 'attribute' or 'querySelector'`
-          + ` inside component '${type}'`
-      );
-    }
-    if (value.selector.type === 'attribute' && typeof value.selector.key !== 'string') {
-      throw new SimulatoError.ELEMENT.ELEMENT_OBJECT_PROPERTY_TYPE(
-        `The selector 'key' field for '${value.name}' must be a string when using selector type attribute`
-          + ` inside component '${type}'`
+        `The selector 'type' field for '${value.name}' must be either 'getElementById', 'querySelector', `
+          + `'querySelectorAll', 'getElementsByTagName', or 'getElementsByClassName' inside component '${type}'`
       );
     }
     if (typeof value.selector.value !== 'string') {

--- a/test/acceptance/components/main-site-layout.js
+++ b/test/acceptance/components/main-site-layout.js
@@ -7,8 +7,7 @@ module.exports = {
       {
         name: 'headerRow',
         selector: {
-          type: 'attribute',
-          key: 'id',
+          type: 'getElementById',
           value: 'siteHeader',
         },
       },

--- a/test/acceptance/components/news-article.js
+++ b/test/acceptance/components/news-article.js
@@ -7,32 +7,28 @@ module.exports = {
       {
         name: 'newsArticle',
         selector: {
-          type: 'attribute',
-          key: 'id',
+          type: 'getElementById',
           value: this.options.newsArticleId,
         },
       },
       {
         name: 'newsArticleImage',
         selector: {
-          type: 'attribute',
-          key: 'id',
+          type: 'getElementById',
           value: `${this.options.newsArticleId}Image`,
         },
       },
       {
         name: 'newsArticleHeading',
         selector: {
-          type: 'attribute',
-          key: 'id',
+          type: 'getElementById',
           value: `${this.options.newsArticleId}Heading`,
         },
       },
       {
         name: 'newsArticleText',
         selector: {
-          type: 'attribute',
-          key: 'id',
+          type: 'getElementById',
           value: `${this.options.newsArticleId}Text`,
         },
       },

--- a/test/acceptance/components/view-story-modal.js
+++ b/test/acceptance/components/view-story-modal.js
@@ -14,24 +14,21 @@ module.exports = {
       {
         name: 'modalTitle',
         selector: {
-          type: 'attribute',
-          key: 'id',
+          type: 'getElementById',
           value: `${this.options.newsArticleId}ModalTitle`,
         },
       },
       {
         name: 'modalBodyText',
         selector: {
-          type: 'attribute',
-          key: 'id',
+          type: 'getElementById',
           value: `${this.options.newsArticleId}ModalBodyText`,
         },
       },
       {
         name: 'closeButton',
         selector: {
-          type: 'attribute',
-          key: 'id',
+          type: 'getElementById',
           value: `${this.options.newsArticleId}ModalCloseButton`,
         },
       },

--- a/test/unit/lib/util/validators/validate-element-tests.js
+++ b/test/unit/lib/util/validators/validate-element-tests.js
@@ -111,7 +111,57 @@ describe('lib/util/validators/validate-elements.js', function() {
         );
       });
 
-      it('should throw an error if value.selector.type is not \'attribute\' or \'querySelector\'', function() {
+      it('should NOT throw an error if the value.selector type is \'getElementById\'', function() {
+        let elements = [{name: 'name', selector: {type: 'getElementById', value: 'value'}}];
+
+        SimulatoError.ELEMENT.ELEMENT_OBJECT_PROPERTY_TYPE.throws(
+          {message: `The selector 'value' field for ${elements[0].name} must be a string`}
+        );
+
+        expect(validateElements.bind(null, elements, instanceName, componentName)).to.not.throw();
+      });
+
+      it('should NOT throw an error if the value.selector type is \'querySelector\'', function() {
+        let elements = [{name: 'name', selector: {type: 'querySelector', value: 'value'}}];
+
+        SimulatoError.ELEMENT.ELEMENT_OBJECT_PROPERTY_TYPE.throws(
+          {message: `The selector 'value' field for ${elements[0].name} must be a string`}
+        );
+
+        expect(validateElements.bind(null, elements, instanceName, componentName)).to.not.throw();
+      });
+
+      it('should NOT throw an error if the value.selector type is \'querySelectorAll\'', function() {
+        let elements = [{name: 'name', selector: {type: 'querySelectorAll', value: 'value'}}];
+
+        SimulatoError.ELEMENT.ELEMENT_OBJECT_PROPERTY_TYPE.throws(
+          {message: `The selector 'value' field for ${elements[0].name} must be a string`}
+        );
+
+        expect(validateElements.bind(null, elements, instanceName, componentName)).to.not.throw();
+      });
+
+      it('should NOT throw an error if the value.selector type is \'getElementsByTagName\'', function() {
+        let elements = [{name: 'name', selector: {type: 'getElementsByTagName', value: 'value'}}];
+
+        SimulatoError.ELEMENT.ELEMENT_OBJECT_PROPERTY_TYPE.throws(
+          {message: `The selector 'value' field for ${elements[0].name} must be a string`}
+        );
+
+        expect(validateElements.bind(null, elements, instanceName, componentName)).to.not.throw();
+      });
+
+      it('should NOT throw an error if the value.selector type is \'getElementsByClassName\'', function() {
+        let elements = [{name: 'name', selector: {type: 'getElementsByClassName', value: 'value'}}];
+
+        SimulatoError.ELEMENT.ELEMENT_OBJECT_PROPERTY_TYPE.throws(
+          {message: `The selector 'value' field for ${elements[0].name} must be a string`}
+        );
+
+        expect(validateElements.bind(null, elements, instanceName, componentName)).to.not.throw();
+      });
+
+      it('should throw an error if value.selector.type is not a valid type', function() {
         let elements = [{name: 'name', selector: {type: 'madeUpType'}}];
 
         SimulatoError.ELEMENT.ELEMENT_OBJECT_PROPERTY_TYPE.throws(
@@ -123,23 +173,8 @@ describe('lib/util/validators/validate-elements.js', function() {
         );
       });
 
-      describe('if the value.selector.type field is \'attribute\'', function() {
-        it('should throw an error if value.selector.key is not a string', function() {
-          let elements = [{name: 'name', selector: {type: 'attribute', key: 1}}];
-
-          SimulatoError.ELEMENT.ELEMENT_OBJECT_PROPERTY_TYPE.throws(
-            {message: `The selector 'key' field for ${elements[0].name}`
-              + ` must be a string when using selector type attribute`}
-          );
-
-          expect(validateElements.bind(null, elements, instanceName, componentName)).to.throw(
-            `The selector 'key' field for name must be a string when using selector type attribute`
-          );
-        });
-      });
-
       it('should throw an error if the value.selector.value is not a string', function() {
-        let elements = [{name: 'name', selector: {type: 'attribute', key: 'key', value: 1}}];
+        let elements = [{name: 'name', selector: {type: 'getElementById', value: 1}}];
 
         SimulatoError.ELEMENT.ELEMENT_OBJECT_PROPERTY_TYPE.throws(
           {message: `The selector 'value' field for ${elements[0].name} must be a string`}
@@ -149,8 +184,9 @@ describe('lib/util/validators/validate-elements.js', function() {
           `The selector 'value' field for name must be a string`
         );
       });
-      it('should throw no error if value.selector.value is a string', function() {
-        let elements = [{name: 'name', selector: {type: 'attribute', key: 'key', value: 'value'}}];
+
+      it('should NOT throw an error if value.selector.value is a string', function() {
+        let elements = [{name: 'name', selector: {type: 'getElementById', value: 'value'}}];
 
         SimulatoError.ELEMENT.ELEMENT_OBJECT_PROPERTY_TYPE.throws(
           {message: `The selector 'value' field for ${elements[0].name} must be a string`}


### PR DESCRIPTION
Resolves issue: #71

Changes proposed in this pull request:
- Changes the selector methods inside elements to use
  - getElementById
  - querySelector
  - querySelectorAll
  - getElementsByTagName
  - getElementsByClassName

@GannettDigital/simulato-core-contributors