### PR TITLE
issue-74: changed test runner to stagger test start times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Pending Version
 
+* Tom Dale
+  * Created a new cli/option command to stagger start time of tests using the test runner
+
 ## 0.3.5
 
 * Brian Fitzpatrick

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ program
     .option('-R, --reportPath [path]', 'The path to write the test result report to')
     .option('-b, --before <path>', 'The path to the before script')
     .option('-f, --configFile <path>', 'The path to the config file')
+    .option('-d, --testDelay <milliseconds>', 'The time in milliseconds to stagger test start times')
     .action(commands.run);
 
 program

--- a/lib/cli/commands/run.js
+++ b/lib/cli/commands/run.js
@@ -64,6 +64,11 @@ module.exports = run = {
             process.env.BEFORE_SCRIPT = path.resolve(before);
         }
 
+        let testDelay = options.testDelay || configFile.testDelay;
+        if (testDelay) {
+            process.env.TEST_DELAY = testDelay;
+        }
+
         let testFilePaths;
         let configureInfo = {};
 

--- a/lib/runner/test-runner/test-runner.js
+++ b/lib/runner/test-runner/test-runner.js
@@ -14,7 +14,7 @@ module.exports = testRunner = {
     _testCount: 0,
     _testTimer: null,
     _timeToStartNextTest: Date.now(),
-    _staggerTime: 50,
+    _staggerTime: 200,
     _testsRemaining: null,
 
     configure(testFiles, parallelism) {

--- a/lib/runner/test-runner/test-runner.js
+++ b/lib/runner/test-runner/test-runner.js
@@ -13,10 +13,17 @@ module.exports = testRunner = {
     _testFiles: [],
     _testCount: 0,
     _testTimer: null,
+    _timeToStartNextTest: Date.now(),
+    _staggerTime: 50,
+    _testsRemaining: null,
 
     configure(testFiles, parallelism) {
         testRunner._testTimer = process.hrtime();
         testRunner._testFiles = testFiles;
+        testRunner._testsRemaining = testFiles.length;
+        if (!Number.isNaN(parseInt(process.env.TEST_DELAY))) {
+            testRunner._staggerTime = parseInt(process.env.TEST_DELAY);
+        }
         if (parallelism && parallelism > 0) {
             testRunner._parallelism = parallelism;
         }
@@ -47,8 +54,9 @@ module.exports = testRunner = {
 
         test.on('close', function() {
             testRunner._testsRunning--;
+            testRunner._testsRemaining--;
             testRunner.emit('testRunner.testFinished');
-            if (testRunner._testsRunning === 0) {
+            if (testRunner._testsRemaining === 0) {
                 testRunner.emit('testRunner.done');
             }
         });
@@ -57,11 +65,19 @@ module.exports = testRunner = {
     },
     _scheduleTests() {
         let numberOfTestsToStart = testRunner._parallelism - testRunner._testsRunning;
-
         for (let i = 0; i < numberOfTestsToStart; i++) {
             let testFile = testRunner._testFiles.pop();
             if (testFile) {
-                testRunner.emit('testRunner.testScheduled', testFile);
+                let now = Date.now();
+                if (now >= testRunner._timeToStartNextTest) {
+                    testRunner._timeToStartNextTest = now + testRunner._staggerTime;
+                    testRunner.emit('testRunner.testScheduled', testFile);
+                } else {
+                    setTimeout(function() {
+                        testRunner.emit('testRunner.testScheduled', testFile);
+                    }, testRunner._timeToStartNextTest - now);
+                    testRunner._timeToStartNextTest += testRunner._staggerTime;
+                }
             } else {
                 break;
             }
@@ -94,6 +110,11 @@ module.exports = testRunner = {
         if (process.env.CONFIG_FILE) {
             spawnArgs.push('-f');
             spawnArgs.push(process.env.CONFIG_FILE);
+        }
+
+        if (process.env.TEST_DELAY) {
+            spawnArgs.push('-d');
+            spawnArgs.push(process.env.TEST_DELAY);
         }
 
         testRunner.emit('testRunner.spawnArgsCreated', spawnArgs);

--- a/test/unit/lib/runner/test-runner/test-runner-tests.js
+++ b/test/unit/lib/runner/test-runner/test-runner-tests.js
@@ -156,7 +156,7 @@ describe('lib/runner/test-runner/test-runner.js', function() {
 
         testRunner.configure([]);
 
-        expect(testRunner._staggerTime).equal(50);
+        expect(testRunner._staggerTime).equal(200);
       });
     });
 


### PR DESCRIPTION
Resolves issue: #74

Changes proposed in this pull request:
- Adds a default time to stagger test start times by 50 ms
- Adds an option that is read in via CLI or options to change time

@GannettDigital/simulato-core-contributors