### PR TITLE
Issue-110: Support Debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Pending Version
 
+* Tom Dale
+  * Added the cli/config command for debug and debugPort
+  * Child processes can be spawn with --inspect-brk
+  * Ports are auto assigned based on availability
+  * Starting Port can be specified
+
 ## 0.5.2
 
 * Tom Dale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Tom Dale
   * Added the cli/config command for debug and debugPort
-  * Child processes can be spawn with --inspect-brk
+  * Child processes can be spawned with --inspect-brk
   * Ports are auto assigned based on availability
   * Starting Port can be specified
 

--- a/docs/_pages/cli.md
+++ b/docs/_pages/cli.md
@@ -48,6 +48,14 @@ This section details the different commands used in the CLI. All passed in CLI o
         * Number of times to rerun failedTests
         * Default is `0`
         * Example: `-F 2`
+    * `-D`, `--debug`
+        * Adds node debugging flag to spawned child processes
+        * Default is `false`
+        * Example: `-D true`
+    * `-P`, `--debugPort`
+        * Specifies the port to start on when using `--debug`
+        * Default is `32489`
+        * Example: `-P 5072`
 
 ## generate
 * Description

--- a/docs/_pages/configuration-file.md
+++ b/docs/_pages/configuration-file.md
@@ -72,6 +72,16 @@ This section documents utilization of the configuration file in place of CLI opt
   * Default is `0`
   * Example: `rerunFailedTests: 2`
 
+### debug
+  * Adds node debugging flag to spawned child processes
+  * Default is `false`
+  * Example: `debug: true`
+    
+### debugPort
+  * Specifies the port to start on when using `--debug`
+  * Default is `32489`
+  * Example: `debugPort: 5072`
+
 ## Example File
     'use strict'
 

--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ program
     .option('-f, --configFile <path>', 'The path to the config file')
     .option('-d, --testDelay <milliseconds>', 'The time in milliseconds to stagger test start times')
     .option('-F, --rerunFailedTests <int>', 'The number of times to rerun failed tests')
+    .option('-D, --debug', 'A flag to turn on debugging when spawning child processes')
+    .option('-P, --debugPort <int>', 'Starting port for debugging when spawning child processes')
     .action(commands.run);
 
 program

--- a/lib/cli/commands/run.js
+++ b/lib/cli/commands/run.js
@@ -74,6 +74,15 @@ module.exports = run = {
             process.env.TEST_RERUN_COUNT = rerunFailedTests;
         }
 
+        let debug = options.debug || configFile.debug;
+        if (debug) {
+            process.env.DEBUG = true;
+            let debugPort = options.debugPort || configFile.debugPort;
+            if (debugPort) {
+                process.env.DEBUG_PORT = debugPort;
+            }
+        }
+
         let testFilePaths;
         let configureInfo = {};
 

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -8,6 +8,8 @@ const PLANNER = require('./planner');
 const TEST_CASE = require('./test-case');
 const EVENT = require('./event');
 const CHILD = require('./child');
+const CLI = require('./cli');
+const RUNNER = require('./runner');
 
 module.exports = {
   ELEMENT,
@@ -18,4 +20,6 @@ module.exports = {
   TEST_CASE,
   EVENT,
   CHILD,
+  CLI,
+  RUNNER,
 };

--- a/lib/errors/runner/index.js
+++ b/lib/errors/runner/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+let SPAWN_CHILD_ERROR = require('./spawn-child-error.js');
+
+module.exports = {
+  SPAWN_CHILD_ERROR,
+};

--- a/lib/errors/runner/runner-error.js
+++ b/lib/errors/runner/runner-error.js
@@ -1,0 +1,7 @@
+'use strict';
+
+let CustomError = require('../custom-error.js');
+
+module.exports = function RUNNER_ERROR(code, message) {
+  return new CustomError('RunnerError', code, message);
+};

--- a/lib/errors/runner/spawn-child-error.js
+++ b/lib/errors/runner/spawn-child-error.js
@@ -1,0 +1,7 @@
+'use strict';
+
+let RunnerError = require('./runner-error.js');
+
+module.exports = function(message) {
+  return new RunnerError('SPAWN_CHILD_ERROR', message);
+};

--- a/lib/runner/runner-event-dispatch/register-runner-events.js
+++ b/lib/runner/runner-event-dispatch/register-runner-events.js
@@ -4,6 +4,7 @@ const testRunner = require('../test-runner/test-runner.js');
 const testReportHandler = require('../test-runner/test-report-handler.js');
 const writeReportToDisk = require('../report-to-disk');
 const reporters = require('../reporters');
+const debugPortHandler = require('../test-runner/debug-port-handler.js');
 
 module.exports = function(runnerEventDispatch) {
     runnerEventDispatch.on('runner.scheduled', testRunner.configure);
@@ -14,6 +15,7 @@ module.exports = function(runnerEventDispatch) {
     testRunner.on('testRunner.testDataReceived', testReportHandler.appendTestReport);
     testRunner.on('testRunner.childStderrReceived', testReportHandler.appendTestStdErr);
     testRunner.on('testRunner.done', testReportHandler.finalizeReport);
+    testRunner.on('testRunner.getDebugPort', debugPortHandler.getPort);
 
     testReportHandler.on('testReportHandler.testReportFinalized', reporters.basic.printTestResult);
     testReportHandler.on('testReportHandler.reportFinalized', writeReportToDisk.json);

--- a/lib/runner/test-runner/debug-port-handler.js
+++ b/lib/runner/test-runner/debug-port-handler.js
@@ -33,7 +33,9 @@ module.exports = debugPortHandler = {
       '127.0.0.1',
       function(error, port) {
         if (error) {
-          throw error;
+          throw new SimulatoError.RUNNER.CHILD_SPAWN_ERROR(
+            `Error while finding debug port for child process: ${error.message}`
+          );
         }
         port === 65535
           ? debugPortHandler._currentPort = debugPortHandler._startPort

--- a/lib/runner/test-runner/debug-port-handler.js
+++ b/lib/runner/test-runner/debug-port-handler.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const portscanner = require('portscanner');
+
+let debugPortHandler;
+module.exports = debugPortHandler = {
+  _startPort: null,
+  _currentPort: null,
+  _maxPort: 65535,
+  _portsToGet: [],
+  _currentlyGettingPort: false,
+  getPort(callback) {
+    debugPortHandler._portsToGet.push(callback);
+
+    if (!debugPortHandler._startPort) {
+      if (!Number.isNaN(parseInt(process.env.DEBUG_PORT))) {
+        debugPortHandler._currentPort = debugPortHandler._startPort = parseInt(process.env.DEBUG_PORT);
+      } else {
+        debugPortHandler._currentPort = debugPortHandler._startPort = 32489;
+      }
+    }
+
+    if (!debugPortHandler._currentlyGettingPort) {
+      debugPortHandler._currentlyGettingPort = true;
+      debugPortHandler._findPort();
+    }
+  },
+  _findPort() {
+    let callback = debugPortHandler._portsToGet.shift();
+    portscanner.findAPortNotInUse(
+      debugPortHandler._currentPort,
+      debugPortHandler._maxPort,
+      '127.0.0.1',
+      function(error, port) {
+        if (error) {
+          throw error;
+        }
+        port === 65535
+          ? debugPortHandler._currentPort = debugPortHandler._startPort
+          : debugPortHandler._currentPort = port + 1;
+        debugPortHandler._sendPort(port, callback);
+        if (debugPortHandler._portsToGet.length) {
+          debugPortHandler._findPort();
+        } else {
+          debugPortHandler._currentlyGettingPort = false;
+        }
+      }
+    );
+  },
+  _sendPort(port, callback) {
+    callback(port);
+  },
+};

--- a/lib/runner/test-runner/test-runner.js
+++ b/lib/runner/test-runner/test-runner.js
@@ -119,13 +119,11 @@ module.exports = testRunner = {
         ];
 
         if (process.env.REPORTER) {
-            spawnArgs.push('-r');
-            spawnArgs.push(process.env.REPORTER);
+            spawnArgs.push('-r', process.env.REPORTER);
         }
 
         if (process.env.OUTPUT_PATH) {
-            spawnArgs.push('-R');
-            spawnArgs.push(process.env.OUTPUT_PATH);
+            spawnArgs.push('-R', process.env.OUTPUT_PATH);
         }
 
         if (process.env.SAUCE_LABS) {
@@ -133,16 +131,21 @@ module.exports = testRunner = {
         }
 
         if (process.env.CONFIG_FILE) {
-            spawnArgs.push('-f');
-            spawnArgs.push(process.env.CONFIG_FILE);
+            spawnArgs.push('-f', process.env.CONFIG_FILE);
         }
 
         if (process.env.TEST_DELAY) {
-            spawnArgs.push('-d');
-            spawnArgs.push(process.env.TEST_DELAY);
+            spawnArgs.push('-d', process.env.TEST_DELAY);
         }
 
-        testRunner.emit('testRunner.spawnArgsCreated', spawnArgs, testPath);
+        if (process.env.DEBUG) {
+            testRunner.emit('testRunner.getDebugPort', function(port) {
+                spawnArgs.unshift(`--inspect-brk=${port}`);
+                testRunner.emit('testRunner.spawnArgsCreated', spawnArgs, testPath);
+            });
+        } else {
+            testRunner.emit('testRunner.spawnArgsCreated', spawnArgs, testPath);
+        }
     },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simulato",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -6195,6 +6195,14 @@
         "kind-of": "3.2.2"
       }
     },
+    "is-number-like": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
+      "requires": {
+        "lodash.isfinite": "3.3.2"
+      }
+    },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
@@ -7880,6 +7888,11 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.isfinite": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9058,6 +9071,15 @@
             "ms": "2.0.0"
           }
         }
+      }
+    },
+    "portscanner": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
+      "integrity": "sha512-IFroCz/59Lqa2uBvzK3bKDbDDIEaAY8XJ1jFxcLWTqosrsc32//P4VuSB2vZXoHiHqOmx8B5L5hnKOxL/7FlPw==",
+      "requires": {
+        "async": "2.6.1",
+        "is-number-like": "1.0.8"
       }
     },
     "posix-character-classes": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "commander": "^2.15.0",
     "lodash": "^4.17.5",
     "palinode": "0.0.7",
+    "portscanner": "2.2.0",
     "sauce-connect-launcher": "^1.2.3",
     "saucelabs": "^1.4.0",
     "selenium-webdriver": "^3.6.0",

--- a/test/unit/lib/cli/commands/run-tests.js
+++ b/test/unit/lib/cli/commands/run-tests.js
@@ -743,9 +743,9 @@ describe('lib/cli/run.js', function() {
                     let options = {};
                     configFile.debugPort = undefined;
                     mockery.registerMock(pathLoc, configFile);
-    
+
                     run.configure(options);
-    
+
                     expect(process.env.DEBUG_PORT).to.equal(undefined);
                 });
             });

--- a/test/unit/lib/cli/commands/run-tests.js
+++ b/test/unit/lib/cli/commands/run-tests.js
@@ -96,6 +96,8 @@ describe('lib/cli/run.js', function() {
                 before: 'script',
                 testDelay: '700',
                 rerunFailedTests: 5,
+                debug: true,
+                debugPort: 5555,
             };
 
             global.SimulatoError = {
@@ -135,6 +137,8 @@ describe('lib/cli/run.js', function() {
             delete process.env.SAUCE_ACCESS_KEY;
             delete process.env.TEST_DELAY;
             delete process.env.TEST_RERUN_COUNT;
+            delete process.env.DEBUG;
+            delete process.env.DEBUG_PORT;
             process.cwd.restore();
             mockery.resetCache();
             mockery.deregisterAll();
@@ -663,6 +667,87 @@ describe('lib/cli/run.js', function() {
                 run.configure(options);
 
                 expect(process.env.TEST_RERUN_COUNT).to.equal(undefined);
+            });
+        });
+
+        describe('if debug is passed in by the options', function() {
+            it('should set process.env.DEBUG to true', function() {
+                let pathLoc = '../../../../config.js';
+                let options = {
+                    debug: true,
+                };
+                mockery.registerMock(pathLoc, configFile);
+
+                run.configure(options);
+
+                expect(process.env.DEBUG).to.equal('true');
+            });
+        });
+
+        describe('if the debug is passed in by the configFile', function() {
+            it('should set process.env.DEBUG to true', function() {
+                let pathLoc = '../../../../config.js';
+                let options = {};
+                mockery.registerMock(pathLoc, configFile);
+
+                run.configure(options);
+
+                expect(process.env.DEBUG).to.equal('true');
+            });
+        });
+
+        describe('if debug is not passed in with configFile or ClI', function() {
+            it('should NOT set process.env.TEST_RERUN_COUNT', function() {
+                let pathLoc = '../../../../config.js';
+                let options = {};
+                configFile.debug = undefined;
+                mockery.registerMock(pathLoc, configFile);
+
+                run.configure(options);
+
+                expect(process.env.DEBUG).to.equal(undefined);
+            });
+        });
+
+        describe('if debug is set', function() {
+            describe('if debugPort is passed in by the options', function() {
+                it('should set process.env.DEBUG_PORT to debugPort', function() {
+                    let pathLoc = '../../../../config.js';
+                    let options = {
+                        debug: true,
+                        debugPort: 4444,
+                    };
+                    mockery.registerMock(pathLoc, configFile);
+
+                    run.configure(options);
+
+                    expect(process.env.DEBUG_PORT).to.equal('4444');
+                });
+            });
+
+            describe('if the debugPort is passed in by the configFile', function() {
+                it('should set process.env.DEBUG_PORT to the configFile.debugPort', function() {
+                    let pathLoc = '../../../../config.js';
+                    let options = {};
+                    mockery.registerMock(pathLoc, configFile);
+
+                    run.configure(options);
+
+                    expect(process.env.DEBUG_PORT).to.equal('5555');
+                });
+            });
+
+            describe('if debugPort is not passed in with configFile or ClI', function() {
+                it('should NOT set process.env.DEBUG_PORT', function() {
+                    let pathLoc = '../../../../config.js';
+                    let options = {};
+                    configFile.debugPort = undefined;
+                    mockery.registerMock(pathLoc, configFile);
+    
+                    run.configure(options);
+    
+                    expect(process.env.DEBUG_PORT).to.equal(undefined);
+                });
             });
         });
 

--- a/test/unit/lib/errors/index-tests.js
+++ b/test/unit/lib/errors/index-tests.js
@@ -13,6 +13,8 @@ describe('lib/errors/index.js', function() {
     let TEST_CASE;
     let EVENT;
     let CHILD;
+    let CLI;
+    let RUNNER;
 
     beforeEach(function() {
         mockery.enable({useCleanCache: true});
@@ -26,6 +28,8 @@ describe('lib/errors/index.js', function() {
         TEST_CASE = sinon.stub();
         EVENT = sinon.stub();
         CHILD = sinon.stub();
+        CLI = sinon.stub();
+        RUNNER = sinon.stub();
 
         mockery.registerMock('./element', ELEMENT);
         mockery.registerMock('./action', ACTION);
@@ -35,6 +39,8 @@ describe('lib/errors/index.js', function() {
         mockery.registerMock('./test-case', TEST_CASE);
         mockery.registerMock('./event', EVENT);
         mockery.registerMock('./child', CHILD);
+        mockery.registerMock('./cli', CLI);
+        mockery.registerMock('./runner', RUNNER);
     });
 
     afterEach(function() {
@@ -43,10 +49,10 @@ describe('lib/errors/index.js', function() {
         mockery.disable();
     });
 
-    it('should export 8 items on an object', function() {
+    it('should export 10 items on an object', function() {
         let result = require('../../../../lib/errors');
 
-        expect(Object.getOwnPropertyNames(result).length).to.equal(8);
+        expect(Object.getOwnPropertyNames(result).length).to.equal(10);
     });
 
     it('should have the property \'ELEMENT\' with the value from requiring'
@@ -103,5 +109,19 @@ describe('lib/errors/index.js', function() {
       let result = require('../../../../lib/errors');
 
       expect(result.CHILD).to.deep.equal(CHILD);
+    });
+
+    it('should have the property \'CLI\' with the value from requiring'
+    + ' \'./cli\'', function() {
+      let result = require('../../../../lib/errors');
+
+      expect(result.CLI).to.deep.equal(CLI);
+    });
+
+    it('should have the property \'RUNNER\' with the value from requiring'
+    + ' \'./runner\'', function() {
+      let result = require('../../../../lib/errors');
+
+      expect(result.RUNNER).to.deep.equal(RUNNER);
     });
 });

--- a/test/unit/lib/errors/runner/child-spawn-error-tests.js
+++ b/test/unit/lib/errors/runner/child-spawn-error-tests.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const mockery = require('mockery');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('lib/errors/runner/spawn-child-error.js', function() {
+  let RunnerError;
+  let goalNotFound;
+
+  beforeEach(function() {
+    mockery.enable({useCleanCache: true});
+    mockery.registerAllowable('../../../../../lib/errors/runner/spawn-child-error.js');
+
+    RunnerError = sinon.stub();
+
+    mockery.registerMock('./runner-error.js', RunnerError);
+
+    goalNotFound = require('../../../../../lib/errors/runner/spawn-child-error.js');
+  });
+
+  afterEach(function() {
+    mockery.resetCache();
+    mockery.deregisterAll();
+    mockery.disable();
+  });
+
+  describe('on execution of the required file', function() {
+    it('should call new RunnerError with \'GOAL_NOT_FOUND\', and passed in message', function() {
+      goalNotFound('ERROR_MESSAGE');
+
+      expect(RunnerError.args).to.deep.equal([
+        ['SPAWN_CHILD_ERROR', 'ERROR_MESSAGE'],
+      ]);
+    });
+
+    it('should return new Runner\Error', function() {
+      let result;
+
+      result = goalNotFound('ERROR_MESSAGE');
+
+      expect(result).to.be.an.instanceof(RunnerError);
+    });
+  });
+});

--- a/test/unit/lib/errors/runner/child-spawn-error-tests.js
+++ b/test/unit/lib/errors/runner/child-spawn-error-tests.js
@@ -26,7 +26,7 @@ describe('lib/errors/runner/spawn-child-error.js', function() {
   });
 
   describe('on execution of the required file', function() {
-    it('should call new RunnerError with \'GOAL_NOT_FOUND\', and passed in message', function() {
+    it('should call new RunnerError with \'SPAWN_CHILD_ERROR\', and passed in message', function() {
       goalNotFound('ERROR_MESSAGE');
 
       expect(RunnerError.args).to.deep.equal([

--- a/test/unit/lib/errors/runner/index-tests.js
+++ b/test/unit/lib/errors/runner/index-tests.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const mockery = require('mockery');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('lib/errors/runner/index.js', function() {
+  let SPAWN_CHILD_ERROR;
+
+  beforeEach(function() {
+    mockery.enable({useCleanCache: true});
+    mockery.registerAllowable('../../../../../lib/errors/runner');
+
+    SPAWN_CHILD_ERROR = sinon.stub();
+
+    mockery.registerMock('./spawn-child-error.js', SPAWN_CHILD_ERROR);
+  });
+
+  afterEach(function() {
+    mockery.resetCache();
+    mockery.deregisterAll();
+    mockery.disable();
+  });
+
+  it('should export 1 item on an object', function() {
+    let result = require('../../../../../lib/errors/runner');
+
+    expect(Object.getOwnPropertyNames(result).length).to.equal(1);
+  });
+
+  it('should have the property \'SPAWN_CHILD_ERROR\' with the value from requiring'
+    + ' \'./child-spawn-error.js\'', function() {
+    let result = require('../../../../../lib/errors/runner');
+
+    expect(result.SPAWN_CHILD_ERROR).to.deep.equal(SPAWN_CHILD_ERROR);
+  });
+});

--- a/test/unit/lib/errors/runner/runner-error-tests.js
+++ b/test/unit/lib/errors/runner/runner-error-tests.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const mockery = require('mockery');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('lib/errors/model/runner-error.js', function() {
+  let CustomError;
+  let runnerError;
+
+  beforeEach(function() {
+    mockery.enable({useCleanCache: true});
+    mockery.registerAllowable('../../../../../lib/errors/runner/runner-error.js');
+
+    CustomError = sinon.stub();
+
+    mockery.registerMock('../custom-error.js', CustomError);
+
+    runnerError = require('../../../../../lib/errors/runner/runner-error.js');
+  });
+
+  afterEach(function() {
+    mockery.resetCache();
+    mockery.deregisterAll();
+    mockery.disable();
+  });
+
+  describe('on execution of the required file', function() {
+    it('should call new CustomError with \'RunnerError\', and passed in code and message', function() {
+      runnerError('ERROR_CODE', 'ERROR_MESSAGE');
+
+      expect(CustomError.args).to.deep.equal([
+        ['RunnerError', 'ERROR_CODE', 'ERROR_MESSAGE'],
+      ]);
+    });
+
+    it('should return new CustomError', function() {
+      let result = runnerError('ERROR_CODE', 'ERROR_MESSAGE');
+
+      expect(result).to.be.an.instanceof(CustomError);
+    });
+  });
+});

--- a/test/unit/lib/runner/runner-event-dispatch/register-runner-events-tests.js
+++ b/test/unit/lib/runner/runner-event-dispatch/register-runner-events-tests.js
@@ -11,6 +11,7 @@ describe('lib/runner/runner-event-dispatch/register-runner-events.js', function(
   let runnerEventDispatch;
   let writeReportToDisk;
   let reporters;
+  let debugPortHandler;
 
   beforeEach(function() {
     mockery.enable({useCleanCache: true});
@@ -40,11 +41,15 @@ describe('lib/runner/runner-event-dispatch/register-runner-events.js', function(
         printReportSummary: sinon.stub(),
       },
     };
+    debugPortHandler = {
+      getPort: sinon.stub(),
+    };
 
     mockery.registerMock('../test-runner/test-runner.js', testRunner);
     mockery.registerMock('../test-runner/test-report-handler.js', testReportHandler);
     mockery.registerMock('../report-to-disk', writeReportToDisk);
     mockery.registerMock('../reporters', reporters);
+    mockery.registerMock('../test-runner/debug-port-handler.js', debugPortHandler);
   });
 
   afterEach(function() {
@@ -153,13 +158,26 @@ describe('lib/runner/runner-event-dispatch/register-runner-events.js', function(
       ]);
     });
 
-    it('should call testRunner.on 5 times', function() {
+    it('should call testRunner.on with testRunner.getDebugPort'
+      + 'and debugPortHandler.getPort', function() {
       registerRunnerEvents = require('../../../../../'
         + 'lib/runner/runner-event-dispatch/register-runner-events.js');
 
       registerRunnerEvents(runnerEventDispatch);
 
-      expect(testRunner.on.callCount).to.equal(5);
+      expect(testRunner.on.args[5]).to.deep.equal([
+        'testRunner.getDebugPort',
+        debugPortHandler.getPort,
+      ]);
+    });
+
+    it('should call testRunner.on 6 times', function() {
+      registerRunnerEvents = require('../../../../../'
+        + 'lib/runner/runner-event-dispatch/register-runner-events.js');
+
+      registerRunnerEvents(runnerEventDispatch);
+
+      expect(testRunner.on.callCount).to.equal(6);
     });
 
     it('should call testReportHandler.on with testReportHandler.testReportFinalized'

--- a/test/unit/lib/runner/test-runner/debug-port-handler-tests.js
+++ b/test/unit/lib/runner/test-runner/debug-port-handler-tests.js
@@ -1,0 +1,252 @@
+'use strict';
+
+const mockery = require('mockery');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('lib/runner/test-runner/debug-port-handler.js', function() {
+  describe('getPort', function() {
+    let debugPortHandler;
+    let callback;
+
+    beforeEach(function() {
+      mockery.enable({useCleanCache: true});
+      mockery.registerAllowable('../../../../../lib/runner/test-runner/debug-port-handler.js');
+
+      callback = sinon.stub();
+
+      mockery.registerMock('portscanner', {});
+
+      debugPortHandler = require('../../../../../lib/runner/test-runner/debug-port-handler.js');
+      debugPortHandler._findPort = sinon.stub();
+      debugPortHandler._startPort = 3000;
+    });
+
+    afterEach(function() {
+      mockery.resetCache();
+      mockery.deregisterAll();
+      mockery.disable();
+      delete process.env.DEBUG_PORT;
+    });
+
+    it('should push the passed in callback to debugPortHandler._portsToGet', function() {
+      let callback2 = sinon.stub();
+      debugPortHandler._portsToGet = [callback2];
+
+      debugPortHandler.getPort(callback);
+
+      expect(debugPortHandler._portsToGet).to.deep.equal([callback2, callback]);
+    });
+
+    describe('if debugPortHandler._startPort is not set', function() {
+      describe('if process.env.DEBUG_PORT is an int', function() {
+        it('should set ._currentPort to proces.env.DEBUG_PORT', function() {
+          process.env.DEBUG_PORT = 2121;
+          delete debugPortHandler._startPort;
+
+          debugPortHandler.getPort(callback);
+
+          expect(debugPortHandler._currentPort).to.equal(2121);
+        });
+
+        it('should set ._startPort to proces.env.DEBUG_PORT', function() {
+          process.env.DEBUG_PORT = 2121;
+          delete debugPortHandler._startPort;
+
+          debugPortHandler.getPort(callback);
+
+          expect(debugPortHandler._startPort).to.equal(2121);
+        });
+      });
+
+      describe('if process.env.DEBUG_PORT is NOT an int', function() {
+        it('should set ._currentPort to the default of 32489', function() {
+          delete debugPortHandler._startPort;
+
+          debugPortHandler.getPort(callback);
+
+          expect(debugPortHandler._currentPort).to.equal(32489);
+        });
+
+        it('should set ._startPort to the default of 32489', function() {
+          delete debugPortHandler._startPort;
+
+          debugPortHandler.getPort(callback);
+
+          expect(debugPortHandler._startPort).to.equal(32489);
+        });
+      });
+    });
+
+    describe('if debugPortHandler._currentlyGettingPort is false', function() {
+      it('should set debugPortHandler._currentlyGettingPort to true', function() {
+        debugPortHandler.getPort(callback);
+
+        expect(debugPortHandler._currentlyGettingPort).to.equal(true);
+      });
+
+      it('should call debugPortHandler._findPort once with no args', function() {
+        debugPortHandler.getPort(callback);
+
+        expect(debugPortHandler._findPort.args).to.deep.equal([[]]);
+      });
+    });
+
+    describe('if debugPortHandler._currentlyGettingPort is true', function() {
+      it('should not call debugPortHanlder._findPort', function() {
+        debugPortHandler._currentlyGettingPort = true;
+
+        debugPortHandler.getPort(callback);
+
+        expect(debugPortHandler._findPort.callCount).to.equal(0);
+      });
+    });
+  });
+
+  describe('_findPort', function() {
+    let debugPortHandler;
+    let portscanner;
+    let callback;
+    let _findPort;
+
+    beforeEach(function() {
+      mockery.enable({useCleanCache: true});
+      mockery.registerAllowable('../../../../../lib/runner/test-runner/debug-port-handler.js');
+
+      portscanner = {
+        findAPortNotInUse: sinon.stub(),
+      };
+      callback = sinon.stub();
+
+      mockery.registerMock('portscanner', portscanner);
+
+      debugPortHandler = require('../../../../../lib/runner/test-runner/debug-port-handler.js');
+      debugPortHandler._portsToGet = [callback];
+      debugPortHandler._sendPort = sinon.stub();
+      debugPortHandler._startPort = 1000;
+      debugPortHandler._currentPort = 1000;
+      _findPort = debugPortHandler._findPort;
+      debugPortHandler._findPort = sinon.stub();
+    });
+
+    afterEach(function() {
+      mockery.resetCache();
+      mockery.deregisterAll();
+      mockery.disable();
+    });
+
+    it('should call portscanner.findAPortNotInUse once', function() {
+      _findPort();
+
+      expect(portscanner.findAPortNotInUse.callCount).to.equal(1);
+    });
+
+    it('should call portscanner.findAPortNotInUse with ' +
+      '._currentPort, ._maxPort, and \'127.0.0.1\' as the first 3 params', function() {
+      _findPort();
+
+      expect(portscanner.findAPortNotInUse.args[0].slice(0, 3)).to.deep.equal([
+        1000,
+        65535,
+        '127.0.0.1',
+      ]);
+    });
+
+    it('should call portscanner.findAPortNotInUse with a function as the 4th param', function() {
+      _findPort();
+
+      expect(portscanner.findAPortNotInUse.args[0][3]).to.be.a('function');
+    });
+
+    describe('when the callback for portscanner.findAPortNotInUse is called', function() {
+      describe('if there was an error returned', function() {
+        it('should throw the error', function() {
+          let err = new Error('im an error being thrown');
+          portscanner.findAPortNotInUse.callsArgWith(3, err);
+
+          expect(_findPort.bind(null)).to.throw('im an error being thrown');
+        });
+      });
+
+      describe('if the returned port is 65535', function() {
+        it('should set debugPortHandler._currentPort to debugPortHandler._startPort', function() {
+          portscanner.findAPortNotInUse.callsArgWith(3, null, 65535);
+          debugPortHandler._currentPort = 33333;
+
+          _findPort();
+
+          expect(debugPortHandler._currentPort).to.equal(1000);
+        });
+      });
+
+      describe('if the returned port is NOT 65535', function() {
+        it('should set debugPortHandler._currentPort to the returned port + 1', function() {
+          portscanner.findAPortNotInUse.callsArgWith(3, null, 1004);
+          debugPortHandler._currentPort = 33333;
+
+          _findPort();
+
+          expect(debugPortHandler._currentPort).to.equal(1005);
+        });
+      });
+
+      it('shoudl call debugPortHandler._sendPort with the returned port ' +
+        'and the callback in debugPortHandler._portsToGet[0]', function() {
+        portscanner.findAPortNotInUse.callsArgWith(3, null, 5000);
+
+        _findPort();
+
+        expect(debugPortHandler._sendPort.args).to.deep.equal([[5000, callback]]);
+      });
+
+      describe('if debugPortHandler._portsToGet is NOT empty', function() {
+        it('shoudl call debugPortHandler._findPort with no args', function() {
+          portscanner.findAPortNotInUse.callsArgWith(3, null, 5000);
+          debugPortHandler._portsToGet.push(sinon.stub());
+
+          _findPort();
+
+          expect(debugPortHandler._findPort.args).to.deep.equal([[]]);
+        });
+      });
+
+      describe('if debugPortHandler._portsToGet is empty', function() {
+        it('should set debugPortHandler._currentlyGettingPort to false', function() {
+          portscanner.findAPortNotInUse.callsArgWith(3, null, 5000);
+
+          _findPort();
+
+          expect(debugPortHandler._currentlyGettingPort).to.equal(false);
+        });
+      });
+    });
+  });
+
+  describe('_sendPort', function() {
+    let debugPortHandler;
+    let callback;
+
+    beforeEach(function() {
+      mockery.enable({useCleanCache: true});
+      mockery.registerAllowable('../../../../../lib/runner/test-runner/debug-port-handler.js');
+
+      callback = sinon.stub();
+
+      mockery.registerMock('portscanner', {});
+
+      debugPortHandler = require('../../../../../lib/runner/test-runner/debug-port-handler.js');
+    });
+
+    afterEach(function() {
+      mockery.resetCache();
+      mockery.deregisterAll();
+      mockery.disable();
+    });
+
+    it('should call the passed in callback with the passed in port', function() {
+      debugPortHandler._sendPort(3402, callback);
+
+      expect(callback.args).to.deep.equal([[3402]]);
+    });
+  });
+});

--- a/test/unit/lib/runner/test-runner/debug-port-handler-tests.js
+++ b/test/unit/lib/runner/test-runner/debug-port-handler-tests.js
@@ -117,6 +117,11 @@ describe('lib/runner/test-runner/debug-port-handler.js', function() {
         findAPortNotInUse: sinon.stub(),
       };
       callback = sinon.stub();
+      global.SimulatoError = {
+        RUNNER: {
+          CHILD_SPAWN_ERROR: sinon.stub(),
+        },
+      };
 
       mockery.registerMock('portscanner', portscanner);
 
@@ -133,6 +138,7 @@ describe('lib/runner/test-runner/debug-port-handler.js', function() {
       mockery.resetCache();
       mockery.deregisterAll();
       mockery.disable();
+      delete global.SimulatoError;
     });
 
     it('should call portscanner.findAPortNotInUse once', function() {
@@ -160,11 +166,15 @@ describe('lib/runner/test-runner/debug-port-handler.js', function() {
 
     describe('when the callback for portscanner.findAPortNotInUse is called', function() {
       describe('if there was an error returned', function() {
-        it('should throw the error', function() {
+        it('should throw simulato CHILD_SPAWN_ERROR', function() {
+          let message = `Error was thrown`;
+          SimulatoError.RUNNER.CHILD_SPAWN_ERROR.throws(
+              {message}
+          );
           let err = new Error('im an error being thrown');
           portscanner.findAPortNotInUse.callsArgWith(3, err);
 
-          expect(_findPort.bind(null)).to.throw('im an error being thrown');
+          expect(_findPort.bind(null)).to.throw('Error was thrown');
         });
       });
 


### PR DESCRIPTION
Resolves issue: #110

Changes proposed in this pull request:
  * Added the cli/config command for debug and debugPort
  * Child processes can be spawn with --inspect-brk
  * Ports are auto assigned based on availability
  * Starting Port can be specified

@GannettDigital/simulato-core-contributors