### PR TITLE
issue-129: fix querySelectorAll bug when no elements are returned

### DIFF
--- a/lib/util/get-element-data.js
+++ b/lib/util/get-element-data.js
@@ -43,7 +43,7 @@ module.exports = function(elementsToGet, callback) {
       return data;
     },
     getElementInfo(data) {
-      if (data.length) {
+      if (data.length || data.length === 0) {
         let elementInfo = [];
         for (let i = 0; i < data.length; i++) {
           elementInfo.push({

--- a/test/unit/lib/util/get-element-data-tests.js
+++ b/test/unit/lib/util/get-element-data-tests.js
@@ -264,6 +264,18 @@ describe('lib/util/get-element-data.js', function() {
         });
       });
 
+      describe('if there is an array with 0 elements passed in', function() {
+        it('should return an empy array', function() {
+          let elements = [];
+          getElementDataFunctions.extractNameAndValue = sinon.stub();
+          getElementDataFunctions.isDisplayed = sinon.stub();
+
+          let result = getElementDataFunctions.getElementInfo(elements);
+
+          expect(result).to.deep.equal([]);
+        });
+      });
+
       describe('if mutiple elements are passed in', function() {
         describe('for each element in the passed in elemenets', function() {
           it('should call extractNameAndValue passing in the element.attributes', function() {

--- a/test/unit/lib/util/get-element-data-tests.js
+++ b/test/unit/lib/util/get-element-data-tests.js
@@ -265,7 +265,7 @@ describe('lib/util/get-element-data.js', function() {
       });
 
       describe('if there is an array with 0 elements passed in', function() {
-        it('should return an empy array', function() {
+        it('should return an empty array', function() {
           let elements = [];
           getElementDataFunctions.extractNameAndValue = sinon.stub();
           getElementDataFunctions.isDisplayed = sinon.stub();
@@ -276,8 +276,8 @@ describe('lib/util/get-element-data.js', function() {
         });
       });
 
-      describe('if mutiple elements are passed in', function() {
-        describe('for each element in the passed in elemenets', function() {
+      describe('if multiple elements are passed in', function() {
+        describe('for each element in the passed in elements', function() {
           it('should call extractNameAndValue passing in the element.attributes', function() {
             let elements = [{
               attributes: ['some', 'attributes'],


### PR DESCRIPTION
Resolves issue: #129 

Changes proposed in this pull request:
- If the data.length of the selector is 0 continue extracting data and let an empy array be returned

@GannettDigital/simulato-core-contributors