### PR TITLE
issue-181: clone when stashing dynamic areas and delete properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Scott Gunther
   * Add JUnit xml report
   * Add first version of offline replanning algorithm
+  * Bug fixes for offline replanning
 
 ## 0.7.0
 

--- a/lib/planner/search-algorithms/offline-replanning.js
+++ b/lib/planner/search-algorithms/offline-replanning.js
@@ -55,6 +55,10 @@ module.exports = offlineReplanning = {
           offlineReplanning._satisfiedActions.add(action);
           yield offlineReplanning.emitAsync('offlineReplanning.updateExistingPlansAndActionOccurrences', next);
         }
+
+        if (backtrackPlan === null && configHandler.get('debug')) {
+          console.log(`Added the following action to the plan: ${action}`);
+        }
       }
       offlineReplanning._savePlan(plan);
     }

--- a/lib/util/expected-state.js
+++ b/lib/util/expected-state.js
@@ -244,6 +244,10 @@ module.exports = ExpectedState = {
     let component = this.getComponent(name);
 
     if (component) {
+      for (let dynamicArea of this._dynamicAreas.values()) {
+        dynamicArea.delete(name);
+      }
+
       this._deregisterEvents(component);
       this._components.delete(name);
       delete this._state[name];
@@ -300,11 +304,12 @@ module.exports = ExpectedState = {
     let dynamicAreaComponentNames;
     if (this._dynamicAreas.get(dynamicArea)) {
       dynamicAreaComponentNames = this._dynamicAreas.get(dynamicArea);
-
       for (let dynamicAreaComponentName of dynamicAreaComponentNames) {
         let component = this.getComponent(dynamicAreaComponentName);
-        stashedDynamicAreaComponents.set(dynamicAreaComponentName, component);
-        stashedDynamicAreaStates.set(dynamicAreaComponentName, this._state[dynamicAreaComponentName]);
+        stashedDynamicAreaComponents.set(dynamicAreaComponentName, this._cloneComponent(component));
+        stashedDynamicAreaStates.set(
+            dynamicAreaComponentName,
+            _.cloneDeep(this._state[dynamicAreaComponentName]));
       }
 
       this._stashedDynamicAreasComponentsAndStates.set(

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,9 +165,9 @@
       }
     },
     "ajv": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-      "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+      "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4025,9 +4025,9 @@
       }
     },
     "eslint": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.9.0.tgz",
-      "integrity": "sha512-g4KWpPdqN0nth+goDNICNXGfJF7nNnepthp46CAlJoJtC5K/cLu3NgCM3AHu1CkJ5Hzt9V0Y0PBAO6Ay/gGb+w==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.10.0.tgz",
+      "integrity": "sha512-HpqzC+BHULKlnPwWae9MaVZ5AXJKpkxCVXQHrFaRw3hbDj26V/9ArYM4Rr/SQ8pi6qUPLXSSXC4RBJlyq2Z2OQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -4039,7 +4039,7 @@
         "eslint-scope": "^4.0.0",
         "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
+        "espree": "^5.0.0",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^2.0.0",
@@ -4049,7 +4049,6 @@
         "ignore": "^4.0.6",
         "imurmurhash": "^0.1.4",
         "inquirer": "^6.1.0",
-        "is-resolvable": "^1.1.0",
         "js-yaml": "^3.12.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
@@ -4382,9 +4381,9 @@
       "dev": true
     },
     "espree": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+      "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.2",
@@ -6306,9 +6305,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-      "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -6322,8 +6321,25 @@
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
         "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
+        "strip-ansi": "^5.0.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
       }
     },
     "internal-ip": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/GannettDigital/simulato#readme",
   "dependencies": {
-    "ajv": "^6.6.1",
+    "ajv": "^6.6.2",
     "chai": "^4.1.2",
     "commander": "^2.18.0",
     "eslint-config-google": "^0.10.0",
@@ -41,7 +41,7 @@
     "xmlbuilder": "^10.1.1"
   },
   "devDependencies": {
-    "eslint": "^5.9.0",
+    "eslint": "^5.10.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.17.0",

--- a/test/unit/lib/planner/search-algorithms/offline-replanning-tests.js
+++ b/test/unit/lib/planner/search-algorithms/offline-replanning-tests.js
@@ -464,6 +464,30 @@ describe('lib/planner/search-algorithms/offline-replanning.js', function() {
             });
           });
 
+          describe('if the returned backtrackPlan is null and configHandler.get returns true', function() {
+            it('should call console.log with a message containing the recently added action', function() {
+              let startNodes = [{path: ['MY_ACTION']}, {path: ['MY_ACTION_2']}];
+              offlineReplanning._satisfiedActions = new Set();
+              offlineReplanning._plans = ['aPlan'];
+              offlineReplanning._getAction.returns('NEXT_ACTION');
+              configHandler.get.returns(true);
+              let generator = offlineReplanning.replan('existingPlans', 'discoveredActions', {testLength: 4});
+
+              generator.next();
+              generator.next(next);
+              generator.next({actionOccurrences: new Map([['MY_ACTION', 1]])});
+              generator.next(startNodes);
+              generator.next();
+              generator.next({applicableActions: ['MY_ACTION_3', 'MY_ACTION_4']});
+              generator.next(null);
+              generator.next();
+
+              expect(console.log.args[1]).to.deep.equal([
+                'Added the following action to the plan: NEXT_ACTION',
+              ]);
+            });
+          });
+
           describe('if the returned backtrackPlan is null and offlineReplanning._satisfiedActions does ' +
             'not have the action', function() {
             it('should call offlineReplanning.emitAsync next with the event "planner.applyEffects"', function() {


### PR DESCRIPTION
Resolves issue: #

Changes proposed in this pull request:
- Log actions as they are added in offline replanning when in debugging mode 
- Delete components from dynamic areas when they components are deleted
- Clone components when stashing the dynamic areas

@GannettDigital/simulato-core-contributors