### PR TITLE
QE-4957 Get test-file name into action report

### DIFF
--- a/lib/runner/writers/j-unit-writer.js
+++ b/lib/runner/writers/j-unit-writer.js
@@ -95,7 +95,7 @@ module.exports = jUnitWriter = {
             let testcase = testsuiteTag.ele('testcase');
             testCount++;
 
-            testcase.att('name', `${action.component}.${action.action}`);
+            testcase.att('name', `${testRun.report.testName}:${action.component}.${action.action}`);
             jUnitWriter._setStatus(action, testcase);
             jUnitWriter._setTime(action, testcase);
 

--- a/test/unit/lib/runner/writers/j-unit-writer-tests.js
+++ b/test/unit/lib/runner/writers/j-unit-writer-tests.js
@@ -538,7 +538,7 @@ describe('lib/runner/writers/j-unit-writer.js', function() {
       it(`should call testcase.att once with the string 'name' and the action's component and action name`, function() {
         jUnitWriter._createReportWithActions(report);
 
-        expect(testcase.att.args).to.deep.equal([['name', 'myComponent.MY_ACTION']]);
+        expect(testcase.att.args).to.deep.equal([['name', '1234_test.json:myComponent.MY_ACTION']]);
       });
 
       it(`should call jUnitWrtier._setStatus once with the action and the testcase`, function() {


### PR DESCRIPTION
Resolves issue: #

Changes proposed in this pull request:
-In action report: append test file name before action name 
-This will allow better test debugging

@GannettDigital/simulato-core-contributors