### PR TITLE
Added deferFailureReports configuration option

### DIFF
--- a/docs/pages/documentation/configuration-file.md
+++ b/docs/pages/documentation/configuration-file.md
@@ -28,6 +28,7 @@ This section documents utilization of the configuration file in place of CLI opt
   * Use to customize the selenium driver
   * See [driver configuration](#driver-configuration)
   * Example: `driver: {<CUSTOM DRIVER CAPABILITIES>}`
+
 ### sauce connect arguments
   * Use to pass options to the embedded suace connect tunnel
   * documentation for options can be found [here](https://www.npmjs.com/package/sauce-connect-launcher)
@@ -50,6 +51,12 @@ This section documents utilization of the configuration file in place of CLI opt
   * Default is `JSON`
   * Values Allowed: `JSON`, `actionJSON`, `JUnit`
   * Example: `reportFormat: 'JSON'`
+
+### deferFailureReports
+  * Whether or not to wait until all tests are finished to show test failure reports
+  * When paralellism is set to zero, this has no effect
+  * Default is `false`
+  * Example: `deferFailureReports: true`
 
 ### jUnitReportSpecificity
   * The levels of detail

--- a/lib/runner/test-runner/test-report-handler.js
+++ b/lib/runner/test-runner/test-report-handler.js
@@ -13,6 +13,7 @@ module.exports = testReportHandler = {
     time: null,
     testReports: [],
   },
+  _failedReports: [],
   startReportHandler() {
     testReportHandler._report.time = process.hrtime();
   },
@@ -57,16 +58,27 @@ module.exports = testReportHandler = {
     if (rerun !== -1 && testRun.report.status === 'fail') {
       testRun.report.status = 'rerun';
       testReport.rerunCount++;
+    } else if (testRun.report.status === 'fail' && configHandler.get('deferFailureReports') === true) {
+      _failedReports.push(testRun.report);
+      return;
     }
     testReportHandler._handleTestReport(testRun.report);
   },
   finalizeReport() {
+    if (configHandler.get('deferFailureReports') === true) {
+      printFailedReports();
+    }
     testReportHandler._report.time = process.hrtime(testReportHandler._report.time);
     if (!testReportHandler._report.failedTestCount) {
       testReportHandler._report.status = 'pass';
     }
     testReportHandler._handleTestReportSummary();
     testReportHandler.emit('testReportHandler.reportFinalized');
+  },
+  printFailedReports() {
+    for (let report of _failedReports) {
+      _handleTestReport(report);
+    }
   },
   _handleTestReport(report) {
     switch (configHandler.get('reporter')) {

--- a/lib/runner/test-runner/test-report-handler.js
+++ b/lib/runner/test-runner/test-report-handler.js
@@ -59,14 +59,14 @@ module.exports = testReportHandler = {
       testRun.report.status = 'rerun';
       testReport.rerunCount++;
     } else if (testRun.report.status === 'fail' && configHandler.get('deferFailureReports') === true) {
-      _failedReports.push(testRun.report);
+      testReportHandler._failedReports.push(testRun.report);
       return;
     }
     testReportHandler._handleTestReport(testRun.report);
   },
   finalizeReport() {
     if (configHandler.get('deferFailureReports') === true) {
-      printFailedReports();
+      testReportHandler._printFailedReports();
     }
     testReportHandler._report.time = process.hrtime(testReportHandler._report.time);
     if (!testReportHandler._report.failedTestCount) {
@@ -75,9 +75,9 @@ module.exports = testReportHandler = {
     testReportHandler._handleTestReportSummary();
     testReportHandler.emit('testReportHandler.reportFinalized');
   },
-  printFailedReports() {
-    for (let report of _failedReports) {
-      _handleTestReport(report);
+  _printFailedReports() {
+    for (let report of testReportHandler._failedReports) {
+      testReportHandler._handleTestReport(report);
     }
   },
   _handleTestReport(report) {

--- a/test/unit/lib/runner/test-runner/test-report-handler-tests.js
+++ b/test/unit/lib/runner/test-runner/test-report-handler-tests.js
@@ -620,7 +620,7 @@ describe('lib/runner/test-runner/test-report-handler.js', function() {
 
       expect(testReportHandler._handleTestReport.args).to.eql([
         ['report1'],
-        ['report2']
+        ['report2'],
       ]);
     });
   });

--- a/test/unit/lib/runner/test-runner/test-report-handler-tests.js
+++ b/test/unit/lib/runner/test-runner/test-report-handler-tests.js
@@ -400,6 +400,68 @@ describe('lib/runner/test-runner/test-report-handler.js', function() {
       });
     });
 
+    describe('if the most recent testRun report status is \'fail\' '
+      + 'and the passed in rerunCount is falsey', function() {
+      describe('when config for deferFailureReports is true', function() {
+        it('should add the report to _failedReports', function() {
+          configHandler.get.returns(true);
+
+          testReportHandler._failedReports = [{
+            status: 'fail',
+            label: 'report1',
+          }];
+
+          testReportHandler._report = {
+            failedTestCount: 3,
+            testReports: [{
+              status: 'fail',
+              rerunCount: 0,
+              testRuns: [{
+                report: {
+                  status: 'fail',
+                  label: 'report2',
+                },
+              }],
+            }],
+          };
+
+          testReportHandler.finalizeTestReport(0, -1);
+
+          expect(testReportHandler._failedReports).to.eql([
+            {
+              status: 'fail',
+              label: 'report1',
+            },
+            {
+              status: 'fail',
+              label: 'report2',
+            },
+          ]);
+        });
+
+        it('should not call _handleTestReport', function() {
+          configHandler.get.returns(true);
+
+          testReportHandler._report = {
+            failedTestCount: 3,
+            testReports: [{
+              status: 'fail',
+              rerunCount: 0,
+              testRuns: [{
+                report: {
+                  status: 'fail',
+                },
+              }],
+            }],
+          };
+
+          testReportHandler.finalizeTestReport(0, -1);
+
+          expect(testReportHandler._handleTestReport.args).to.eql([]);
+        });
+      });
+    });
+
     it('should call _handleTestReport with the report of the passed in testNumber most recent testRun', function() {
       testReportHandler._report.testReports[0] = {
         rerunCount: 0,
@@ -446,6 +508,7 @@ describe('lib/runner/test-runner/test-report-handler.js', function() {
       mockery.registerMock('../../util/config/config-handler.js', configHandler);
 
       testReportHandler = require('../../../../../lib/runner/test-runner/test-report-handler.js');
+      testReportHandler._printFailedReports = sinon.stub();
       testReportHandler._handleTestReportSummary = sinon.stub();
     });
 
@@ -454,6 +517,18 @@ describe('lib/runner/test-runner/test-report-handler.js', function() {
       mockery.deregisterAll();
       mockery.disable();
       process.hrtime.restore();
+    });
+
+    describe('when the config for deferFailureReports is true', function() {
+      it('should call printFailedReports', function() {
+        configHandler.get.returns(true);
+
+        testReportHandler.finalizeReport();
+
+        expect(testReportHandler._printFailedReports.args).to.eql([
+          [],
+        ]);
+      });
     });
 
     it('should call process.hrtime once', function() {
@@ -499,6 +574,53 @@ describe('lib/runner/test-runner/test-report-handler.js', function() {
         [
           'testReportHandler.reportFinalized',
         ],
+      ]);
+    });
+  });
+
+  describe('_printFailedReports', function() {
+    let testReportHandler;
+    let Emitter;
+
+    beforeEach(function() {
+      mockery.enable({useCleanCache: true});
+      mockery.registerAllowable('../../../../../lib/runner/test-runner/test-report-handler.js');
+
+      Emitter = {
+        mixIn: function(myObject) {
+          myObject.on = sinon.stub();
+          myObject.emit = sinon.stub();
+        },
+      };
+      sinon.spy(Emitter, 'mixIn');
+
+      sinon.stub(process, 'hrtime').returns([4, 54321]);
+
+      mockery.registerMock('../../util/emitter.js', Emitter);
+      mockery.registerMock('../runner-event-dispatch/runner-event-dispatch.js', {});
+      mockery.registerMock('../../util/config/config-handler.js', {});
+
+      testReportHandler = require('../../../../../lib/runner/test-runner/test-report-handler.js');
+      testReportHandler._handleTestReport = sinon.stub();
+    });
+
+    afterEach(function() {
+      mockery.resetCache();
+      mockery.deregisterAll();
+      mockery.disable();
+      process.hrtime.restore();
+    });
+
+    it('should call _handleTestReport for every failed report', function() {
+      testReportHandler._failedReports = [
+        'report1', 'report2',
+      ];
+
+      testReportHandler._printFailedReports();
+
+      expect(testReportHandler._handleTestReport.args).to.eql([
+        ['report1'],
+        ['report2']
       ]);
     });
   });

--- a/test/unit/lib/runner/test-runner/test-report-handler-tests.js
+++ b/test/unit/lib/runner/test-runner/test-report-handler-tests.js
@@ -405,12 +405,10 @@ describe('lib/runner/test-runner/test-report-handler.js', function() {
       describe('when config for deferFailureReports is true', function() {
         it('should add the report to _failedReports', function() {
           configHandler.get.returns(true);
-
           testReportHandler._failedReports = [{
             status: 'fail',
             label: 'report1',
           }];
-
           testReportHandler._report = {
             failedTestCount: 3,
             testReports: [{
@@ -441,7 +439,6 @@ describe('lib/runner/test-runner/test-report-handler.js', function() {
 
         it('should not call _handleTestReport', function() {
           configHandler.get.returns(true);
-
           testReportHandler._report = {
             failedTestCount: 3,
             testReports: [{

--- a/test/unit/lib/runner/test-runner/test-report-handler-tests.js
+++ b/test/unit/lib/runner/test-runner/test-report-handler-tests.js
@@ -263,11 +263,16 @@ describe('lib/runner/test-runner/test-report-handler.js', function() {
 
   describe('finalizeTestReport', function() {
     let testReportHandler;
+    let configHandler;
     let Emitter;
 
     beforeEach(function() {
       mockery.enable({useCleanCache: true});
       mockery.registerAllowable('../../../../../lib/runner/test-runner/test-report-handler.js');
+
+      configHandler = {
+        get: sinon.stub(),
+      };
 
       Emitter = {
         mixIn: function(myObject) {
@@ -279,7 +284,7 @@ describe('lib/runner/test-runner/test-report-handler.js', function() {
 
       mockery.registerMock('../../util/emitter.js', Emitter);
       mockery.registerMock('../runner-event-dispatch/runner-event-dispatch.js', {});
-      mockery.registerMock('../../util/config/config-handler.js', {});
+      mockery.registerMock('../../util/config/config-handler.js', configHandler);
 
       testReportHandler = require('../../../../../lib/runner/test-runner/test-report-handler.js');
       testReportHandler._handleTestReport = sinon.stub();
@@ -415,11 +420,16 @@ describe('lib/runner/test-runner/test-report-handler.js', function() {
 
   describe('finalizeReport', function() {
     let testReportHandler;
+    let configHandler;
     let Emitter;
 
     beforeEach(function() {
       mockery.enable({useCleanCache: true});
       mockery.registerAllowable('../../../../../lib/runner/test-runner/test-report-handler.js');
+
+      configHandler = {
+        get: sinon.stub(),
+      };
 
       Emitter = {
         mixIn: function(myObject) {
@@ -433,7 +443,7 @@ describe('lib/runner/test-runner/test-report-handler.js', function() {
 
       mockery.registerMock('../../util/emitter.js', Emitter);
       mockery.registerMock('../runner-event-dispatch/runner-event-dispatch.js', {});
-      mockery.registerMock('../../util/config/config-handler.js', {});
+      mockery.registerMock('../../util/config/config-handler.js', configHandler);
 
       testReportHandler = require('../../../../../lib/runner/test-runner/test-report-handler.js');
       testReportHandler._handleTestReportSummary = sinon.stub();


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds `deferFailureReports` configuration option to stop failures from printing out until the end of all tests. This defaults to false, so shouldn't affect any pre-existing runs

@GannettDigital/simulato-core-contributors